### PR TITLE
chore: Update dependencies

### DIFF
--- a/Apache.Druid.Querying.Microsoft.Extensions.DependencyInjection/Apache.Druid.Querying.Microsoft.Extensions.DependencyInjection.csproj
+++ b/Apache.Druid.Querying.Microsoft.Extensions.DependencyInjection/Apache.Druid.Querying.Microsoft.Extensions.DependencyInjection.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="DotNet.ReproducibleBuilds" Version="1.2.4" />
+    <PackageReference Update="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageReference Update="MinVer" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Apache.Druid.Querying.Tests.Integration/Apache.Druid.Querying.Tests.Integration.csproj
+++ b/Apache.Druid.Querying.Tests.Integration/Apache.Druid.Querying.Tests.Integration.csproj
@@ -13,26 +13,26 @@
 
   <ItemGroup>
     <PackageReference Include="Ductus.FluentDocker" Version="2.10.59" />
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="LinqKit.Core" Version="1.2.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="LinqKit.Core" Version="1.2.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="morelinq" Version="4.3.0" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.12" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="morelinq" Version="4.4.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Snapshooter.NUnit" Version="0.14.1" />
+    <PackageReference Include="Snapshooter.NUnit" Version="1.0.0" />
     <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
-    <PackageReference Include="ToxiproxyNetCore" Version="1.0.35" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="ToxiproxyNetCore" Version="1.0.40" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Apache.Druid.Querying.Tests.Unit/Apache.Druid.Querying.Tests.Unit.csproj
+++ b/Apache.Druid.Querying.Tests.Unit/Apache.Druid.Querying.Tests.Unit.csproj
@@ -11,20 +11,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="morelinq" Version="4.3.0" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="morelinq" Version="4.4.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Snapshooter.NUnit" Version="0.14.1" />
+    <PackageReference Include="Snapshooter.NUnit" Version="1.0.0" />
     <PackageReference Include="System.Interactive" Version="6.0.1" />
     <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
   </ItemGroup>

--- a/Apache.Druid.Querying/Apache.Druid.Querying.csproj
+++ b/Apache.Druid.Querying/Apache.Druid.Querying.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="DotNet.ReproducibleBuilds" Version="1.2.4" />
+    <PackageReference Update="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageReference Update="MinVer" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This PR updates all dependencies to their newest version supporting .NET 6.
No breaking changes have been found when going through each updated package changelog.